### PR TITLE
Fix WordPressSite deployment and ingress reconciliation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,4 +60,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,7 @@
 name: Build and Push Controller Docker Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -60,4 +61,3 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
-

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ go.work
 sites/
 /TODO
 test
+
+# system files
+.DS_Store

--- a/api/v1/wordpresssite_types.go
+++ b/api/v1/wordpresssite_types.go
@@ -78,6 +78,10 @@ type WordPressConfig struct {
 	// Resource requirements for the WordPress pod
 	// +optional
 	Resources *ResourceRequirements `json:"resources,omitempty"`
+
+	// ImagePullSecret references an optional pull secret for private WordPress images
+	// +optional
+	ImagePullSecret string `json:"imagePullSecret,omitempty"`
 }
 
 // EnvVar represents an environment variable in a container

--- a/dist/chart/templates/crd/wordpresssites.crm.hostzero.de.yaml
+++ b/dist/chart/templates/crd/wordpresssites.crm.hostzero.de.yaml
@@ -150,6 +150,9 @@ spec:
                                         default: wordpress:latest
                                         description: Image to use for the WordPress container
                                         type: string
+                                    imagePullSecret:
+                                        description: ImagePullSecret references an optional pull secret for private WordPress images
+                                        type: string
                                     maxUploadLimit:
                                         default: 64M
                                         description: MaxUploadLimit sets the maximum upload file size (e.g., "64M")

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -57,7 +57,7 @@ spec:
                       value: {{ .Chart.AppVersion }}
                   command:
                     - /manager
-                  image: "{{ .Values.manager.image.repository }}:{{ .Chart.AppVersion }}"
+                  image: "{{ .Values.manager.image.repository }}:{{ default .Chart.AppVersion .Values.manager.image.tag }}"
                   imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
                   livenessProbe:
                     httpGet:

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -27,6 +27,9 @@ spec:
                 app.kubernetes.io/managed-by: {{ .Release.Service }}
                 app.kubernetes.io/version: {{ .Chart.Version | replace "+" "_" }}
         spec:
+            {{- with .Values.manager.imagePullSecrets }}
+            imagePullSecrets: {{ toYaml . | nindent 16 }}
+            {{- end }}
             {{- with .Values.manager.tolerations }}
             tolerations: {{ toYaml . | nindent 16 }}
             {{- end }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -12,7 +12,8 @@ manager:
   replicas: 1
   
   image:
-    repository: ghcr.io/hostzero-gmbh/kubepress/controller
+    repository: ghcr.io/permanet-io/kubepress/controller
+    tag: main
     pullPolicy: IfNotPresent
 
   ## Arguments
@@ -31,6 +32,8 @@ manager:
     STORAGE_CLASS_NAME: csi-cephfs-sc # the StorageClass to be used for PersistentVolumeClaims created by Kubepress, must be created beforehand, on those PVCs live the data of WordPress
     CILIUM_SHARING_KEY: "kubepress" # the sharing key to be used for Cilium's Shared IP feature, this will apply to all ingresses for the SFTP service
     CILIUM_REQUESTED_IPS: "10.101.254.110" # the IP address (or addresses) to be used for Cilium's Shared IP feature, this will apply to all service for the SFTP service, make sure that this IP is not in use
+    SFTP_SERVICE_TYPE: ClusterIP # set to LoadBalancer only when SFTP should be exposed outside the cluster
+    WORDPRESS_IMAGE_PULL_SECRET: "" # optional imagePullSecret for private WordPress site images
     PHPMYADMIN_ENABLED: "true" # whether to create a phpMyAdmin instance for each Namespace, existing instances won't be deleted if you set this to false, but no new instances will be created
     PHPMYADMIN_DOMAIN: "phpmyadmin.hostzero.com" # the domain to be used for the phpMyAdmin instance, make sure that this domain points to your cluster
 
@@ -56,7 +59,6 @@ manager:
   ##
   resources:
     limits:
-        cpu: 500m
         memory: 128Mi
     requests:
         cpu: 10m
@@ -107,4 +109,3 @@ certManager:
 ##
 prometheus:
   enable: false
-

--- a/internal/controller/wordpress/deployment.go
+++ b/internal/controller/wordpress/deployment.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -173,6 +174,18 @@ if ! /tmp/wp-cli core is-installed --path="/var/www/html/" --quiet 2>/dev/null; 
 		--allow-root
 fi
 
+if [ "${KUBEPRESS_SYNC_WP_CONTENT:-false}" = "true" ]; then
+	for subdir in themes plugins mu-plugins; do
+		src="/usr/src/wordpress/wp-content/${subdir}"
+		dst="/var/www/html/wp-content/${subdir}"
+		if [ -d "$src" ]; then
+			echo "Syncing ${subdir} from image into WordPress content volume..."
+			mkdir -p "$dst"
+			cp -a "$src/." "$dst/"
+		fi
+	done
+fi
+
 # Set proper ownership and permissions
 chown -R 33:33 /var/www/html
 `},
@@ -190,6 +203,7 @@ chown -R 33:33 /var/www/html
 				{Name: "WORDPRESS_MEMORY_LIMIT", Value: memoryLimit},
 			},
 		}
+		initContainer.Env = append(initContainer.Env, wp.Spec.WordPress.Env...)
 
 		// Create Pod specification
 		podSpec := corev1.PodSpec{
@@ -264,19 +278,14 @@ chown -R 33:33 /var/www/html
 						},
 					},
 					VolumeMounts: volumeMounts,
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse(wp.Spec.WordPress.Resources.CPURequest),
-							corev1.ResourceMemory: resource.MustParse(wp.Spec.WordPress.Resources.MemoryRequest),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse(wp.Spec.WordPress.Resources.CPULimit),
-							corev1.ResourceMemory: resource.MustParse(wp.Spec.WordPress.Resources.MemoryLimit),
-						},
-					},
+					Resources: buildWordPressResources(wp),
 				},
 			},
 			Volumes: volumes,
+		}
+		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, wp.Spec.WordPress.Env...)
+		if imagePullSecret := resolveImagePullSecret(wp); imagePullSecret != "" {
+			podSpec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: imagePullSecret}}
 		}
 
 		// Create the deployment
@@ -323,6 +332,10 @@ chown -R 33:33 /var/www/html
 			deployment.Spec.Template.Spec.Containers[0].Image = wp.Spec.WordPress.Image
 			updateNeeded = true
 		}
+		if len(deployment.Spec.Template.Spec.InitContainers) > 0 && deployment.Spec.Template.Spec.InitContainers[0].Image != wp.Spec.WordPress.Image {
+			deployment.Spec.Template.Spec.InitContainers[0].Image = wp.Spec.WordPress.Image
+			updateNeeded = true
+		}
 
 		// Check if replicas need to be updated
 		if *deployment.Spec.Replicas != wp.Spec.WordPress.Replicas {
@@ -332,22 +345,28 @@ chown -R 33:33 /var/www/html
 
 		// Add environment variables handling
 		if len(wp.Spec.WordPress.Env) > 0 {
-			if envVarsChanged := updateEnvVars(deployment, wp.Spec.WordPress.Env, logger); envVarsChanged {
+			if envVarsChanged := updateEnvVars(&deployment.Spec.Template.Spec.Containers[0].Env, wp.Spec.WordPress.Env, logger); envVarsChanged {
 				updateNeeded = true
+			}
+			if len(deployment.Spec.Template.Spec.InitContainers) > 0 {
+				if envVarsChanged := updateEnvVars(&deployment.Spec.Template.Spec.InitContainers[0].Env, wp.Spec.WordPress.Env, logger); envVarsChanged {
+					updateNeeded = true
+				}
 			}
 		}
 
-		// Check if resource requests/limits need to be updated
-		resources := corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse(wp.Spec.WordPress.Resources.CPURequest),
-				corev1.ResourceMemory: resource.MustParse(wp.Spec.WordPress.Resources.MemoryRequest),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse(wp.Spec.WordPress.Resources.CPULimit),
-				corev1.ResourceMemory: resource.MustParse(wp.Spec.WordPress.Resources.MemoryLimit),
-			},
+		if imagePullSecret := resolveImagePullSecret(wp); imagePullSecret != "" && !imagePullSecretsEqual(deployment.Spec.Template.Spec.ImagePullSecrets, imagePullSecret) {
+			deployment.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: imagePullSecret}}
+			updateNeeded = true
 		}
+
+		if imagePullSecret := resolveImagePullSecret(wp); imagePullSecret == "" && len(deployment.Spec.Template.Spec.ImagePullSecrets) > 0 {
+			deployment.Spec.Template.Spec.ImagePullSecrets = nil
+			updateNeeded = true
+		}
+
+		// Check if resource requests/limits need to be updated
+		resources := buildWordPressResources(wp)
 
 		if !resourcesEqual(deployment.Spec.Template.Spec.Containers[0].Resources, resources) {
 			deployment.Spec.Template.Spec.Containers[0].Resources = resources
@@ -362,7 +381,7 @@ chown -R 33:33 /var/www/html
 		}
 
 		// check if init container has the correct memory limit env var
-		if deployment.Spec.Template.Spec.InitContainers[0].Env != nil {
+		if len(deployment.Spec.Template.Spec.InitContainers) > 0 && deployment.Spec.Template.Spec.InitContainers[0].Env != nil {
 			for i, env := range deployment.Spec.Template.Spec.InitContainers[0].Env {
 				if env.Name == "WORDPRESS_MEMORY_LIMIT" {
 					if env.Value != memoryLimit {
@@ -372,7 +391,7 @@ chown -R 33:33 /var/www/html
 					break
 				}
 			}
-		} else {
+		} else if len(deployment.Spec.Template.Spec.InitContainers) > 0 {
 			// add the env var
 			deployment.Spec.Template.Spec.InitContainers[0].Env = []corev1.EnvVar{
 				{
@@ -396,6 +415,40 @@ chown -R 33:33 /var/www/html
 	return nil
 }
 
+func buildWordPressResources(wp *crmv1.WordPressSite) corev1.ResourceRequirements {
+	resources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{},
+		Limits:   corev1.ResourceList{},
+	}
+
+	if wp.Spec.WordPress.Resources == nil {
+		return resources
+	}
+
+	if wp.Spec.WordPress.Resources.CPURequest != "" {
+		resources.Requests[corev1.ResourceCPU] = resource.MustParse(wp.Spec.WordPress.Resources.CPURequest)
+	}
+	if wp.Spec.WordPress.Resources.MemoryRequest != "" {
+		resources.Requests[corev1.ResourceMemory] = resource.MustParse(wp.Spec.WordPress.Resources.MemoryRequest)
+	}
+	if wp.Spec.WordPress.Resources.MemoryLimit != "" {
+		resources.Limits[corev1.ResourceMemory] = resource.MustParse(wp.Spec.WordPress.Resources.MemoryLimit)
+	}
+
+	return resources
+}
+
+func resolveImagePullSecret(wp *crmv1.WordPressSite) string {
+	if wp.Spec.WordPress.ImagePullSecret != "" {
+		return wp.Spec.WordPress.ImagePullSecret
+	}
+	return os.Getenv("WORDPRESS_IMAGE_PULL_SECRET")
+}
+
+func imagePullSecretsEqual(actual []corev1.LocalObjectReference, expected string) bool {
+	return len(actual) == 1 && actual[0].Name == expected
+}
+
 func resourcesEqual(requirements corev1.ResourceRequirements, actual corev1.ResourceRequirements) bool {
 	if len(requirements.Limits) != len(actual.Limits) || len(requirements.Requests) != len(actual.Requests) {
 		return false
@@ -417,28 +470,31 @@ func resourcesEqual(requirements corev1.ResourceRequirements, actual corev1.Reso
 
 }
 
-// updateEnvVars updates environment variables in a deployment
-func updateEnvVars(deployment *appsv1.Deployment, envVars []crmv1.EnvVar, logger logr.Logger) bool {
+// updateEnvVars updates environment variables in a container.
+func updateEnvVars(containerEnv *[]corev1.EnvVar, envVars []crmv1.EnvVar, logger logr.Logger) bool {
 	changed := false
-
-	// First, create a map of existing env vars to avoid duplicates
-	existingEnvVars := make(map[string]bool)
-	for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
-		existingEnvVars[env.Name] = true
+	existingEnvVars := make(map[string]int)
+	for i, env := range *containerEnv {
+		existingEnvVars[env.Name] = i
 	}
 
-	// Only add env vars that don't already exist
 	for _, env := range envVars {
-		if !existingEnvVars[env.Name] {
-			deployment.Spec.Template.Spec.Containers[0].Env = append(
-				deployment.Spec.Template.Spec.Containers[0].Env,
-				corev1.EnvVar{
-					Name:  env.Name,
-					Value: env.Value,
-				},
-			)
-			changed = true
+		if existingIndex, ok := existingEnvVars[env.Name]; ok {
+			if (*containerEnv)[existingIndex].Value != env.Value {
+				(*containerEnv)[existingIndex].Value = env.Value
+				changed = true
+			}
+			continue
 		}
+
+		*containerEnv = append(
+			*containerEnv,
+			corev1.EnvVar{
+				Name:  env.Name,
+				Value: env.Value,
+			},
+		)
+		changed = true
 	}
 
 	return changed

--- a/internal/controller/wordpress/deployment.go
+++ b/internal/controller/wordpress/deployment.go
@@ -3,7 +3,6 @@ package wordpress
 import (
 	"context"
 	"fmt"
-	"github.com/go-logr/logr"
 	crmv1 "hostzero.de/m/v2/api/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -319,11 +318,11 @@ chown -R 33:33 /var/www/html
 
 		// Add environment variables handling
 		if len(wp.Spec.WordPress.Env) > 0 {
-			if envVarsChanged := updateEnvVars(&deployment.Spec.Template.Spec.Containers[0].Env, wp.Spec.WordPress.Env, logger); envVarsChanged {
+			if envVarsChanged := updateEnvVars(&deployment.Spec.Template.Spec.Containers[0].Env, wp.Spec.WordPress.Env); envVarsChanged {
 				updateNeeded = true
 			}
 			if len(deployment.Spec.Template.Spec.InitContainers) > 0 {
-				if envVarsChanged := updateEnvVars(&deployment.Spec.Template.Spec.InitContainers[0].Env, wp.Spec.WordPress.Env, logger); envVarsChanged {
+				if envVarsChanged := updateEnvVars(&deployment.Spec.Template.Spec.InitContainers[0].Env, wp.Spec.WordPress.Env); envVarsChanged {
 					updateNeeded = true
 				}
 			}
@@ -424,6 +423,9 @@ func buildWordPressResources(wp *crmv1.WordPressSite) corev1.ResourceRequirement
 	if wp.Spec.WordPress.Resources.CPURequest != "" {
 		resources.Requests[corev1.ResourceCPU] = resource.MustParse(wp.Spec.WordPress.Resources.CPURequest)
 	}
+	if wp.Spec.WordPress.Resources.CPULimit != "" {
+		resources.Limits[corev1.ResourceCPU] = resource.MustParse(wp.Spec.WordPress.Resources.CPULimit)
+	}
 	if wp.Spec.WordPress.Resources.MemoryRequest != "" {
 		resources.Requests[corev1.ResourceMemory] = resource.MustParse(wp.Spec.WordPress.Resources.MemoryRequest)
 	}
@@ -477,8 +479,8 @@ func resourcesEqual(requirements corev1.ResourceRequirements, actual corev1.Reso
 
 }
 
-// updateEnvVars updates environment variables in a container.
-func updateEnvVars(containerEnv *[]corev1.EnvVar, envVars []crmv1.EnvVar, logger logr.Logger) bool {
+// updateEnvVars updates custom environment variables in a container.
+func updateEnvVars(containerEnv *[]corev1.EnvVar, envVars []crmv1.EnvVar) bool {
 	changed := false
 	existingEnvVars := make(map[string]int)
 	for i, env := range *containerEnv {
@@ -486,6 +488,10 @@ func updateEnvVars(containerEnv *[]corev1.EnvVar, envVars []crmv1.EnvVar, logger
 	}
 
 	for _, env := range envVars {
+		if isManagedEnvVar(env.Name) {
+			continue
+		}
+
 		if existingIndex, ok := existingEnvVars[env.Name]; ok {
 			if (*containerEnv)[existingIndex].Value != env.Value {
 				(*containerEnv)[existingIndex].Value = env.Value
@@ -505,6 +511,27 @@ func updateEnvVars(containerEnv *[]corev1.EnvVar, envVars []crmv1.EnvVar, logger
 	}
 
 	return changed
+}
+
+func isManagedEnvVar(name string) bool {
+	switch name {
+	case "WORDPRESS_DB_HOST",
+		"WORDPRESS_DB_NAME",
+		"WORDPRESS_DB_USER",
+		"WORDPRESS_DB_PASSWORD",
+		"WORDPRESS_TABLE_PREFIX",
+		"APACHE_RUN_USER",
+		"APACHE_RUN_GROUP",
+		"WORDPRESS_URL",
+		"WORDPRESS_TITLE",
+		"WORDPRESS_ADMIN_USER",
+		"WORDPRESS_ADMIN_PASSWORD",
+		"WORDPRESS_ADMIN_EMAIL",
+		"WORDPRESS_MEMORY_LIMIT":
+		return true
+	default:
+		return false
+	}
 }
 
 func upsertEnvVar(containerEnv *[]corev1.EnvVar, desired corev1.EnvVar) bool {

--- a/internal/controller/wordpress/deployment.go
+++ b/internal/controller/wordpress/deployment.go
@@ -203,7 +203,7 @@ chown -R 33:33 /var/www/html
 				{Name: "WORDPRESS_MEMORY_LIMIT", Value: memoryLimit},
 			},
 		}
-		initContainer.Env = append(initContainer.Env, wp.Spec.WordPress.Env...)
+		initContainer.Env = append(initContainer.Env, toCoreEnvVars(wp.Spec.WordPress.Env)...)
 
 		// Create Pod specification
 		podSpec := corev1.PodSpec{
@@ -283,7 +283,7 @@ chown -R 33:33 /var/www/html
 			},
 			Volumes: volumes,
 		}
-		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, wp.Spec.WordPress.Env...)
+		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, toCoreEnvVars(wp.Spec.WordPress.Env)...)
 		if imagePullSecret := resolveImagePullSecret(wp); imagePullSecret != "" {
 			podSpec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: imagePullSecret}}
 		}
@@ -447,6 +447,17 @@ func resolveImagePullSecret(wp *crmv1.WordPressSite) string {
 
 func imagePullSecretsEqual(actual []corev1.LocalObjectReference, expected string) bool {
 	return len(actual) == 1 && actual[0].Name == expected
+}
+
+func toCoreEnvVars(envVars []crmv1.EnvVar) []corev1.EnvVar {
+	coreEnvVars := make([]corev1.EnvVar, 0, len(envVars))
+	for _, env := range envVars {
+		coreEnvVars = append(coreEnvVars, corev1.EnvVar{
+			Name:  env.Name,
+			Value: env.Value,
+		})
+	}
+	return coreEnvVars
 }
 
 func resourcesEqual(requirements corev1.ResourceRequirements, actual corev1.ResourceRequirements) bool {

--- a/internal/controller/wordpress/deployment.go
+++ b/internal/controller/wordpress/deployment.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"os"
+	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -190,18 +191,7 @@ fi
 chown -R 33:33 /var/www/html
 `},
 			VolumeMounts: volumeMounts, // share volumes with main container if needed
-			Env: []corev1.EnvVar{
-				{Name: "WORDPRESS_DB_HOST", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: mySQLSecretName}, Key: "databaseHost"}}},
-				{Name: "WORDPRESS_DB_NAME", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: mySQLSecretName}, Key: "database"}}},
-				{Name: "WORDPRESS_DB_USER", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: mySQLSecretName}, Key: "databaseUsername"}}},
-				{Name: "WORDPRESS_DB_PASSWORD", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: mySQLSecretName}, Key: "databasePassword"}}},
-				{Name: "WORDPRESS_URL", Value: getSiteUrl(wp)},
-				{Name: "WORDPRESS_TITLE", Value: wp.Spec.SiteTitle},
-				{Name: "WORDPRESS_ADMIN_USER", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: mySQLSecretName}, Key: "username"}}},
-				{Name: "WORDPRESS_ADMIN_PASSWORD", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: mySQLSecretName}, Key: "password"}}},
-				{Name: "WORDPRESS_ADMIN_EMAIL", Value: wp.Spec.AdminEmail},
-				{Name: "WORDPRESS_MEMORY_LIMIT", Value: memoryLimit},
-			},
+			Env:          desiredInitEnvVars(wp, mySQLSecretName, memoryLimit),
 		}
 		initContainer.Env = append(initContainer.Env, toCoreEnvVars(wp.Spec.WordPress.Env)...)
 
@@ -241,23 +231,7 @@ chown -R 33:33 /var/www/html
 					//		Add:  []corev1.Capability{"CHOWN", "SETUID", "SETGID"}, // Minimal capabilities
 					//	},
 					//},
-					Env: []corev1.EnvVar{
-						{
-							Name:      "WORDPRESS_DB_HOST",
-							ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: mySQLSecretName}, Key: "databaseHost"}},
-						},
-						{
-							Name:      "WORDPRESS_DB_NAME",
-							ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: mySQLSecretName}, Key: "database"}},
-						},
-						{
-							Name:      "WORDPRESS_DB_USER",
-							ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: mySQLSecretName}, Key: "databaseUsername"}},
-						},
-						{
-							Name:      "WORDPRESS_DB_PASSWORD",
-							ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: mySQLSecretName}, Key: "databasePassword"}},
-						},
+					Env: append(desiredWordPressContainerEnvVars(mySQLSecretName), []corev1.EnvVar{
 						{
 							Name:  "WORDPRESS_TABLE_PREFIX",
 							Value: "wp_",
@@ -270,7 +244,7 @@ chown -R 33:33 /var/www/html
 							Name:  "APACHE_RUN_GROUP",
 							Value: "www-data",
 						},
-					},
+					}...),
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http",
@@ -278,7 +252,7 @@ chown -R 33:33 /var/www/html
 						},
 					},
 					VolumeMounts: volumeMounts,
-					Resources: buildWordPressResources(wp),
+					Resources:    buildWordPressResources(wp),
 				},
 			},
 			Volumes: volumes,
@@ -355,6 +329,13 @@ chown -R 33:33 /var/www/html
 			}
 		}
 
+		mySQLSecretName := wp.Spec.AdminUserSecretKeyRef
+		for _, envVar := range desiredWordPressContainerEnvVars(mySQLSecretName) {
+			if upsertEnvVar(&deployment.Spec.Template.Spec.Containers[0].Env, envVar) {
+				updateNeeded = true
+			}
+		}
+
 		if imagePullSecret := resolveImagePullSecret(wp); imagePullSecret != "" && !imagePullSecretsEqual(deployment.Spec.Template.Spec.ImagePullSecrets, imagePullSecret) {
 			deployment.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: imagePullSecret}}
 			updateNeeded = true
@@ -380,26 +361,12 @@ chown -R 33:33 /var/www/html
 			return err
 		}
 
-		// check if init container has the correct memory limit env var
-		if len(deployment.Spec.Template.Spec.InitContainers) > 0 && deployment.Spec.Template.Spec.InitContainers[0].Env != nil {
-			for i, env := range deployment.Spec.Template.Spec.InitContainers[0].Env {
-				if env.Name == "WORDPRESS_MEMORY_LIMIT" {
-					if env.Value != memoryLimit {
-						deployment.Spec.Template.Spec.InitContainers[0].Env[i].Value = memoryLimit
-						updateNeeded = true
-					}
-					break
+		if len(deployment.Spec.Template.Spec.InitContainers) > 0 {
+			for _, envVar := range desiredInitEnvVars(wp, mySQLSecretName, memoryLimit) {
+				if upsertEnvVar(&deployment.Spec.Template.Spec.InitContainers[0].Env, envVar) {
+					updateNeeded = true
 				}
 			}
-		} else if len(deployment.Spec.Template.Spec.InitContainers) > 0 {
-			// add the env var
-			deployment.Spec.Template.Spec.InitContainers[0].Env = []corev1.EnvVar{
-				{
-					Name:  "WORDPRESS_MEMORY_LIMIT",
-					Value: memoryLimit,
-				},
-			}
-			updateNeeded = true
 		}
 
 		// Update the deployment if needed
@@ -413,6 +380,35 @@ chown -R 33:33 /var/www/html
 	}
 
 	return nil
+}
+
+func desiredWordPressContainerEnvVars(secretName string) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{Name: "WORDPRESS_DB_HOST", ValueFrom: secretKeyEnv(secretName, "databaseHost")},
+		{Name: "WORDPRESS_DB_NAME", ValueFrom: secretKeyEnv(secretName, "database")},
+		{Name: "WORDPRESS_DB_USER", ValueFrom: secretKeyEnv(secretName, "databaseUsername")},
+		{Name: "WORDPRESS_DB_PASSWORD", ValueFrom: secretKeyEnv(secretName, "databasePassword")},
+	}
+}
+
+func desiredInitEnvVars(wp *crmv1.WordPressSite, secretName, memoryLimit string) []corev1.EnvVar {
+	return append(desiredWordPressContainerEnvVars(secretName), []corev1.EnvVar{
+		{Name: "WORDPRESS_URL", Value: getSiteUrl(wp)},
+		{Name: "WORDPRESS_TITLE", Value: wp.Spec.SiteTitle},
+		{Name: "WORDPRESS_ADMIN_USER", ValueFrom: secretKeyEnv(secretName, "username")},
+		{Name: "WORDPRESS_ADMIN_PASSWORD", ValueFrom: secretKeyEnv(secretName, "password")},
+		{Name: "WORDPRESS_ADMIN_EMAIL", Value: wp.Spec.AdminEmail},
+		{Name: "WORDPRESS_MEMORY_LIMIT", Value: memoryLimit},
+	}...)
+}
+
+func secretKeyEnv(secretName, key string) *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+			Key:                  key,
+		},
+	}
 }
 
 func buildWordPressResources(wp *crmv1.WordPressSite) corev1.ResourceRequirements {
@@ -509,6 +505,22 @@ func updateEnvVars(containerEnv *[]corev1.EnvVar, envVars []crmv1.EnvVar, logger
 	}
 
 	return changed
+}
+
+func upsertEnvVar(containerEnv *[]corev1.EnvVar, desired corev1.EnvVar) bool {
+	for i, env := range *containerEnv {
+		if env.Name != desired.Name {
+			continue
+		}
+		if reflect.DeepEqual(env, desired) {
+			return false
+		}
+		(*containerEnv)[i] = desired
+		return true
+	}
+
+	*containerEnv = append(*containerEnv, desired)
+	return true
 }
 
 // Helper functions to get values from the WordPress spec

--- a/internal/controller/wordpress/deployment_test.go
+++ b/internal/controller/wordpress/deployment_test.go
@@ -1,0 +1,138 @@
+package wordpress
+
+import (
+	"context"
+	"testing"
+
+	crmv1 "hostzero.de/m/v2/api/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcileDeploymentUpdatesBuiltInEnvVars(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := crmv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	wp := &crmv1.WordPressSite{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example",
+			Namespace: "default",
+			UID:       types.UID("7bce6ded-8660-4ae6-8c32-a3c93f42a715"),
+		},
+		Spec: crmv1.WordPressSiteSpec{
+			SiteTitle:             "New title",
+			AdminEmail:            "new-admin@example.com",
+			AdminUserSecretKeyRef: "new-secret",
+			Ingress: &crmv1.IngressConfig{
+				Enabled: true,
+				Host:    "new.example.com",
+				TLS:     true,
+			},
+			WordPress: crmv1.WordPressConfig{
+				Image:    "wordpress:new",
+				Replicas: 1,
+				Resources: &crmv1.ResourceRequirements{
+					MemoryLimit: "2Gi",
+				},
+			},
+		},
+	}
+
+	replicas := int32(1)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{
+						Name:  "init",
+						Image: "wordpress:old",
+						Env: []corev1.EnvVar{
+							{Name: "WORDPRESS_URL", Value: "https://old.example.com"},
+							{Name: "WORDPRESS_TITLE", Value: "Old title"},
+							{Name: "WORDPRESS_ADMIN_EMAIL", Value: "old-admin@example.com"},
+							{Name: "WORDPRESS_MEMORY_LIMIT", Value: "512M"},
+							{Name: "WORDPRESS_ADMIN_USER", ValueFrom: secretKeyEnv("old-secret", "username")},
+						},
+					}},
+					Containers: []corev1.Container{{
+						Name:  "wordpress",
+						Image: "wordpress:old",
+						Env: []corev1.EnvVar{
+							{Name: "WORDPRESS_DB_HOST", ValueFrom: secretKeyEnv("old-secret", "databaseHost")},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
+	if err := ReconcileDeployment(ctx, client, scheme, wp); err != nil {
+		t.Fatalf("ReconcileDeployment returned error: %v", err)
+	}
+
+	var got appsv1.Deployment
+	if err := client.Get(ctx, types.NamespacedName{Name: "example", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("failed to get deployment: %v", err)
+	}
+
+	initEnv := got.Spec.Template.Spec.InitContainers[0].Env
+	assertEnvValue(t, initEnv, "WORDPRESS_URL", "https://new.example.com")
+	assertEnvValue(t, initEnv, "WORDPRESS_TITLE", "New title")
+	assertEnvValue(t, initEnv, "WORDPRESS_ADMIN_EMAIL", "new-admin@example.com")
+	assertEnvValue(t, initEnv, "WORDPRESS_MEMORY_LIMIT", "2048M")
+	assertSecretRef(t, initEnv, "WORDPRESS_ADMIN_USER", "new-secret", "username")
+	assertSecretRef(t, initEnv, "WORDPRESS_ADMIN_PASSWORD", "new-secret", "password")
+
+	containerEnv := got.Spec.Template.Spec.Containers[0].Env
+	assertSecretRef(t, containerEnv, "WORDPRESS_DB_HOST", "new-secret", "databaseHost")
+	assertSecretRef(t, containerEnv, "WORDPRESS_DB_NAME", "new-secret", "database")
+	assertSecretRef(t, containerEnv, "WORDPRESS_DB_USER", "new-secret", "databaseUsername")
+	assertSecretRef(t, containerEnv, "WORDPRESS_DB_PASSWORD", "new-secret", "databasePassword")
+}
+
+func assertEnvValue(t *testing.T, env []corev1.EnvVar, name, expected string) {
+	t.Helper()
+	for _, item := range env {
+		if item.Name == name {
+			if item.Value != expected {
+				t.Fatalf("env %s = %q, want %q", name, item.Value, expected)
+			}
+			return
+		}
+	}
+	t.Fatalf("env %s not found", name)
+}
+
+func assertSecretRef(t *testing.T, env []corev1.EnvVar, name, secretName, key string) {
+	t.Helper()
+	for _, item := range env {
+		if item.Name != name {
+			continue
+		}
+		if item.ValueFrom == nil || item.ValueFrom.SecretKeyRef == nil {
+			t.Fatalf("env %s has no secret key ref", name)
+		}
+		ref := item.ValueFrom.SecretKeyRef
+		if ref.Name != secretName || ref.Key != key {
+			t.Fatalf("env %s references %s/%s, want %s/%s", name, ref.Name, ref.Key, secretName, key)
+		}
+		return
+	}
+	t.Fatalf("env %s not found", name)
+}

--- a/internal/controller/wordpress/deployment_test.go
+++ b/internal/controller/wordpress/deployment_test.go
@@ -112,6 +112,23 @@ func TestReconcileDeploymentUpdatesBuiltInEnvVars(t *testing.T) {
 	assertSecretRef(t, containerEnv, "WORDPRESS_DB_PASSWORD", "new-secret", "databasePassword")
 }
 
+func TestUpdateEnvVarsSkipsManagedEnvVars(t *testing.T) {
+	env := []corev1.EnvVar{
+		{Name: "WORDPRESS_DB_HOST", ValueFrom: secretKeyEnv("db-secret", "databaseHost")},
+	}
+
+	changed := updateEnvVars(&env, []crmv1.EnvVar{
+		{Name: "WORDPRESS_DB_HOST", Value: "override.example.com"},
+		{Name: "CUSTOM_SETTING", Value: "enabled"},
+	})
+
+	if !changed {
+		t.Fatal("updateEnvVars did not report adding custom env var")
+	}
+	assertSecretRef(t, env, "WORDPRESS_DB_HOST", "db-secret", "databaseHost")
+	assertEnvValue(t, env, "CUSTOM_SETTING", "enabled")
+}
+
 func assertEnvValue(t *testing.T, env []corev1.EnvVar, name, expected string) {
 	t.Helper()
 	for _, item := range env {

--- a/internal/controller/wordpress/deployment_test.go
+++ b/internal/controller/wordpress/deployment_test.go
@@ -42,7 +42,10 @@ func TestReconcileDeploymentUpdatesBuiltInEnvVars(t *testing.T) {
 				Image:    "wordpress:new",
 				Replicas: 1,
 				Resources: &crmv1.ResourceRequirements{
-					MemoryLimit: "2Gi",
+					CPULimit:      "1000m",
+					CPURequest:    "250m",
+					MemoryLimit:   "2Gi",
+					MemoryRequest: "512Mi",
 				},
 			},
 		},
@@ -91,13 +94,16 @@ func TestReconcileDeploymentUpdatesBuiltInEnvVars(t *testing.T) {
 		t.Fatalf("failed to get deployment: %v", err)
 	}
 
-	initEnv := got.Spec.Template.Spec.InitContainers[0].Env
-	assertEnvValue(t, initEnv, "WORDPRESS_URL", "https://new.example.com")
-	assertEnvValue(t, initEnv, "WORDPRESS_TITLE", "New title")
-	assertEnvValue(t, initEnv, "WORDPRESS_ADMIN_EMAIL", "new-admin@example.com")
-	assertEnvValue(t, initEnv, "WORDPRESS_MEMORY_LIMIT", "2048M")
-	assertSecretRef(t, initEnv, "WORDPRESS_ADMIN_USER", "new-secret", "username")
-	assertSecretRef(t, initEnv, "WORDPRESS_ADMIN_PASSWORD", "new-secret", "password")
+	initContainer := got.Spec.Template.Spec.InitContainers[0]
+	if initContainer.Image != "wordpress:new" {
+		t.Fatalf("init image = %q, want wordpress:new", initContainer.Image)
+	}
+	assertEnvValue(t, initContainer.Env, "WORDPRESS_URL", "https://new.example.com")
+	assertEnvValue(t, initContainer.Env, "WORDPRESS_TITLE", "New title")
+	assertEnvValue(t, initContainer.Env, "WORDPRESS_ADMIN_EMAIL", "new-admin@example.com")
+	assertEnvValue(t, initContainer.Env, "WORDPRESS_MEMORY_LIMIT", "2048M")
+	assertSecretRef(t, initContainer.Env, "WORDPRESS_ADMIN_USER", "new-secret", "username")
+	assertSecretRef(t, initContainer.Env, "WORDPRESS_ADMIN_PASSWORD", "new-secret", "password")
 
 	containerEnv := got.Spec.Template.Spec.Containers[0].Env
 	assertSecretRef(t, containerEnv, "WORDPRESS_DB_HOST", "new-secret", "databaseHost")

--- a/internal/controller/wordpress/sftp.go
+++ b/internal/controller/wordpress/sftp.go
@@ -173,7 +173,7 @@ func ReconcileSFTPDeployment(ctx context.Context, r client.Client, scheme *runti
 						Containers: []corev1.Container{
 							{
 								Name:         "sftp",
-								Image:        "atmoz/sftp:latest",
+								Image:        getEnv("SFTP_IMAGE", "atmoz/sftp:latest"),
 								Env:          env,
 								VolumeMounts: volumeMounts,
 								Ports: []corev1.ContainerPort{
@@ -243,7 +243,7 @@ func ReconcileSFTPDeployment(ctx context.Context, r client.Client, scheme *runti
 				Annotations: annotations,
 			},
 			Spec: corev1.ServiceSpec{
-				Type:     corev1.ServiceTypeLoadBalancer,
+				Type:     getSFTPServiceType(),
 				Selector: GetSFTPLabels(wp),
 				Ports: []corev1.ServicePort{{
 					Name:       "sftp",
@@ -270,6 +270,24 @@ func ReconcileSFTPDeployment(ctx context.Context, r client.Client, scheme *runti
 	}
 
 	return nil
+}
+
+func getEnv(name string, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func getSFTPServiceType() corev1.ServiceType {
+	switch os.Getenv("SFTP_SERVICE_TYPE") {
+	case string(corev1.ServiceTypeLoadBalancer):
+		return corev1.ServiceTypeLoadBalancer
+	case string(corev1.ServiceTypeNodePort):
+		return corev1.ServiceTypeNodePort
+	default:
+		return corev1.ServiceTypeClusterIP
+	}
 }
 
 func getAvailablePort(ctx context.Context, r client.Client, logger logr.Logger) (int, error) {

--- a/internal/controller/wordpresssite_controller.go
+++ b/internal/controller/wordpresssite_controller.go
@@ -61,6 +61,11 @@ const (
 )
 
 const (
+	ingressReadyWithoutLoadBalancerAnnotation = "kubepress.hostzero.de/ingress-ready-without-load-balancer"
+	legacyIngressClassAnnotation              = "kubernetes.io/ingress.class"
+)
+
+const (
 	StatusUnknown                   = "Unknown"                   // Initial status, not set yet
 	StatusValidationFailed          = "ValidationFailed"          // Validation failed, e.g. the domain is already in use
 	StatusContainerReady            = "ContainerReady"            // Container is ready, first status to set
@@ -514,12 +519,37 @@ func (r *WordPressSiteReconciler) isIngressReady(ctx context.Context, wp *crmv1.
 		return addr.IP != "" || addr.Hostname != "", nil
 	}
 
-	// Some ingress controllers, including Traefik in pn-k8s, do not populate
-	// ingress.status.loadBalancer for cluster-internal ingress classes. If the
-	// reconciled Ingress exists and points at the expected host/backend, treat
-	// it as deployed rather than keeping an externally reachable site NotReady.
-	if wp.Spec.Ingress == nil || wp.Spec.Ingress.Host == "" {
+	if ingressAllowsReadyWithoutLoadBalancer(ingress) && ingressRoutesToWordPressService(ingress, wp) {
 		return true, nil
+	}
+
+	return false, nil
+}
+
+func ingressAllowsReadyWithoutLoadBalancer(ingress *networkingv1.Ingress) bool {
+	if strings.EqualFold(ingress.Annotations[ingressReadyWithoutLoadBalancerAnnotation], "true") {
+		return true
+	}
+
+	ingressClassName := ""
+	if ingress.Spec.IngressClassName != nil {
+		ingressClassName = *ingress.Spec.IngressClassName
+	}
+	if ingressClassName == "" {
+		ingressClassName = ingress.Annotations[legacyIngressClassAnnotation]
+	}
+
+	switch strings.ToLower(ingressClassName) {
+	case "cloudflare-tunnel", "cloudflared", "cloudflare-warp":
+		return true
+	default:
+		return false
+	}
+}
+
+func ingressRoutesToWordPressService(ingress *networkingv1.Ingress, wp *crmv1.WordPressSite) bool {
+	if wp.Spec.Ingress == nil || wp.Spec.Ingress.Host == "" {
+		return false
 	}
 
 	serviceName := wordpress.GetResourceName(wp.Name)
@@ -528,13 +558,29 @@ func (r *WordPressSiteReconciler) isIngressReady(ctx context.Context, wp *crmv1.
 			continue
 		}
 		for _, path := range rule.HTTP.Paths {
-			if path.Backend.Service != nil && path.Backend.Service.Name == serviceName {
-				return true, nil
+			if !isExpectedWordPressPath(path) {
+				continue
+			}
+			if path.Backend.Service != nil &&
+				path.Backend.Service.Name == serviceName &&
+				isExpectedWordPressServicePort(path.Backend.Service.Port) {
+				return true
 			}
 		}
 	}
 
-	return false, nil
+	return false
+}
+
+func isExpectedWordPressPath(path networkingv1.HTTPIngressPath) bool {
+	if path.Path != "/" {
+		return false
+	}
+	return path.PathType == nil || *path.PathType == networkingv1.PathTypePrefix
+}
+
+func isExpectedWordPressServicePort(port networkingv1.ServiceBackendPort) bool {
+	return port.Number == 80 || port.Name == "http"
 }
 
 // getMySQLVersionDirect queries the MySQL version directly

--- a/internal/controller/wordpresssite_controller.go
+++ b/internal/controller/wordpresssite_controller.go
@@ -404,13 +404,16 @@ func (r *WordPressSiteReconciler) updateStatus(ctx context.Context, wp *crmv1.Wo
 
 	// Check if WordPress deployment is ready
 	status := StatusUnknown
+	notReadyMessage := "WordPress site readiness has not been determined"
 
 	// Find WordPress pod regardless of CLI setting
 	podList := &v1.PodList{}
 	labels := wordpress.GetWordpressLabelsForMatching(wp)
 	if err := r.List(ctx, podList, client.InNamespace(wp.Namespace), client.MatchingLabels(labels)); err == nil {
+		notReadyMessage = "WordPress pod not found"
 		for _, pod := range podList.Items {
 			if pod.Status.Phase == v1.PodRunning {
+				notReadyMessage = "WordPress pod is running but containers are not ready"
 				// Pod is running, check if it's ready
 				podReady := false
 				for _, condition := range pod.Status.Conditions {
@@ -429,6 +432,7 @@ func (r *WordPressSiteReconciler) updateStatus(ctx context.Context, wp *crmv1.Wo
 		}
 	} else {
 		logger.Error(err, "Failed to list WordPress pods")
+		notReadyMessage = "Failed to list WordPress pods"
 	}
 
 	// Check if WordPress is installed & db is ready
@@ -437,10 +441,13 @@ func (r *WordPressSiteReconciler) updateStatus(ctx context.Context, wp *crmv1.Wo
 		installed, err := r.isWordPressInstalled(ctx, wp)
 		if err != nil {
 			logger.Error(err, "updateStatus: Failed to check if WordPressSite is installed")
+			notReadyMessage = "Failed to check WordPress installation status"
 		} else if installed {
 			// Emit event for installation detected
 			r.Recorder.Event(wp, v1.EventTypeNormal, "InstallationDetected", "WordPress installation detected")
 			status = StatusWordPressReady
+		} else {
+			notReadyMessage = "WordPress installation not detected"
 		}
 	}
 
@@ -454,9 +461,12 @@ func (r *WordPressSiteReconciler) updateStatus(ctx context.Context, wp *crmv1.Wo
 			ingressReady, err := r.isIngressReady(ctx, wp)
 			if err != nil {
 				logger.Error(err, "Failed to check if Ingress is ready")
+				notReadyMessage = "Failed to check WordPress ingress"
 			} else if ingressReady {
 				r.Recorder.Event(wp, v1.EventTypeNormal, "IngressReady", "Detected Ingress is ready for WordPress site")
 				status = StatusWordPressReadyAndDeployed
+			} else {
+				notReadyMessage = "WordPress ingress is not ready"
 			}
 		}
 	}
@@ -473,7 +483,7 @@ func (r *WordPressSiteReconciler) updateStatus(ctx context.Context, wp *crmv1.Wo
 	if status == StatusWordPressReadyAndDeployed {
 		wordpress.SetCondition(wp, "Ready", metav1.ConditionTrue, "Ready", "WordPress site is ready")
 	} else {
-		wordpress.SetCondition(wp, "Ready", metav1.ConditionFalse, "NotReady", "WordPress pod not found")
+		wordpress.SetCondition(wp, "Ready", metav1.ConditionFalse, "NotReady", notReadyMessage)
 	}
 
 	// Set the Ready status field - this directly updates the status.ready field in the CRD
@@ -503,6 +513,27 @@ func (r *WordPressSiteReconciler) isIngressReady(ctx context.Context, wp *crmv1.
 		addr := ingress.Status.LoadBalancer.Ingress[0]
 		return addr.IP != "" || addr.Hostname != "", nil
 	}
+
+	// Some ingress controllers, including Traefik in pn-k8s, do not populate
+	// ingress.status.loadBalancer for cluster-internal ingress classes. If the
+	// reconciled Ingress exists and points at the expected host/backend, treat
+	// it as deployed rather than keeping an externally reachable site NotReady.
+	if wp.Spec.Ingress == nil || wp.Spec.Ingress.Host == "" {
+		return true, nil
+	}
+
+	serviceName := wordpress.GetResourceName(wp.Name)
+	for _, rule := range ingress.Spec.Rules {
+		if rule.Host != wp.Spec.Ingress.Host || rule.HTTP == nil {
+			continue
+		}
+		for _, path := range rule.HTTP.Paths {
+			if path.Backend.Service != nil && path.Backend.Service.Name == serviceName {
+				return true, nil
+			}
+		}
+	}
+
 	return false, nil
 }
 

--- a/internal/controller/wordpresssite_controller_test.go
+++ b/internal/controller/wordpresssite_controller_test.go
@@ -1,0 +1,106 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	crmv1 "hostzero.de/m/v2/api/v1"
+	"hostzero.de/m/v2/internal/controller/wordpress"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestIsIngressReadyAcceptsMatchingIngressWithoutLoadBalancerStatus(t *testing.T) {
+	reconciler := newTestReconciler(t, newIngress("site", "default", "site.example.com", "site"))
+	wp := newWordPressSite("site.example.com")
+
+	ready, err := reconciler.isIngressReady(context.Background(), wp)
+	if err != nil {
+		t.Fatalf("isIngressReady returned error: %v", err)
+	}
+	if !ready {
+		t.Fatal("isIngressReady returned false for matching ingress without load balancer status")
+	}
+}
+
+func TestIsIngressReadyRejectsStaleIngressHost(t *testing.T) {
+	reconciler := newTestReconciler(t, newIngress("site", "default", "old.example.com", "site"))
+	wp := newWordPressSite("site.example.com")
+
+	ready, err := reconciler.isIngressReady(context.Background(), wp)
+	if err != nil {
+		t.Fatalf("isIngressReady returned error: %v", err)
+	}
+	if ready {
+		t.Fatal("isIngressReady returned true for ingress with stale host")
+	}
+}
+
+func newTestReconciler(t *testing.T, objects ...*networkingv1.Ingress) *WordPressSiteReconciler {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := crmv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := networkingv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, object := range objects {
+		builder.WithObjects(object)
+	}
+
+	return &WordPressSiteReconciler{Client: builder.Build(), Scheme: scheme}
+}
+
+func newWordPressSite(host string) *crmv1.WordPressSite {
+	return &crmv1.WordPressSite{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "site",
+			Namespace: "default",
+		},
+		Spec: crmv1.WordPressSiteSpec{
+			Ingress: &crmv1.IngressConfig{
+				Enabled: true,
+				Host:    host,
+			},
+		},
+	}
+}
+
+func newIngress(name, namespace, host, serviceName string) *networkingv1.Ingress {
+	pathType := networkingv1.PathTypePrefix
+	return &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: host,
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: &pathType,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: wordpress.GetResourceName(serviceName),
+											Port: networkingv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/controller/wordpresssite_controller_test.go
+++ b/internal/controller/wordpresssite_controller_test.go
@@ -12,8 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestIsIngressReadyAcceptsMatchingIngressWithoutLoadBalancerStatus(t *testing.T) {
-	reconciler := newTestReconciler(t, newIngress("site", "default", "site.example.com", "site"))
+func TestIsIngressReadyAcceptsExplicitTunnelIngressWithoutLoadBalancerStatus(t *testing.T) {
+	reconciler := newTestReconciler(t, newIngress("site", "default", "site.example.com", "site", map[string]string{
+		ingressReadyWithoutLoadBalancerAnnotation: "true",
+	}, ""))
 	wp := newWordPressSite("site.example.com")
 
 	ready, err := reconciler.isIngressReady(context.Background(), wp)
@@ -21,12 +23,40 @@ func TestIsIngressReadyAcceptsMatchingIngressWithoutLoadBalancerStatus(t *testin
 		t.Fatalf("isIngressReady returned error: %v", err)
 	}
 	if !ready {
-		t.Fatal("isIngressReady returned false for matching ingress without load balancer status")
+		t.Fatal("isIngressReady returned false for explicit tunnel ingress without load balancer status")
+	}
+}
+
+func TestIsIngressReadyAcceptsCloudflareTunnelIngressClassWithoutLoadBalancerStatus(t *testing.T) {
+	reconciler := newTestReconciler(t, newIngress("site", "default", "site.example.com", "site", nil, "cloudflare-tunnel"))
+	wp := newWordPressSite("site.example.com")
+
+	ready, err := reconciler.isIngressReady(context.Background(), wp)
+	if err != nil {
+		t.Fatalf("isIngressReady returned error: %v", err)
+	}
+	if !ready {
+		t.Fatal("isIngressReady returned false for Cloudflare Tunnel ingress class without load balancer status")
+	}
+}
+
+func TestIsIngressReadyRejectsMatchingIngressWithoutLoadBalancerSignal(t *testing.T) {
+	reconciler := newTestReconciler(t, newIngress("site", "default", "site.example.com", "site", nil, ""))
+	wp := newWordPressSite("site.example.com")
+
+	ready, err := reconciler.isIngressReady(context.Background(), wp)
+	if err != nil {
+		t.Fatalf("isIngressReady returned error: %v", err)
+	}
+	if ready {
+		t.Fatal("isIngressReady returned true for matching ingress without load balancer or tunnel signal")
 	}
 }
 
 func TestIsIngressReadyRejectsStaleIngressHost(t *testing.T) {
-	reconciler := newTestReconciler(t, newIngress("site", "default", "old.example.com", "site"))
+	reconciler := newTestReconciler(t, newIngress("site", "default", "old.example.com", "site", map[string]string{
+		ingressReadyWithoutLoadBalancerAnnotation: "true",
+	}, ""))
 	wp := newWordPressSite("site.example.com")
 
 	ready, err := reconciler.isIngressReady(context.Background(), wp)
@@ -72,12 +102,13 @@ func newWordPressSite(host string) *crmv1.WordPressSite {
 	}
 }
 
-func newIngress(name, namespace, host, serviceName string) *networkingv1.Ingress {
+func newIngress(name, namespace, host, serviceName string, annotations map[string]string, ingressClassName string) *networkingv1.Ingress {
 	pathType := networkingv1.PathTypePrefix
-	return &networkingv1.Ingress{
+	ingress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
 		},
 		Spec: networkingv1.IngressSpec{
 			Rules: []networkingv1.IngressRule{
@@ -103,4 +134,8 @@ func newIngress(name, namespace, host, serviceName string) *networkingv1.Ingress
 			},
 		},
 	}
+	if ingressClassName != "" {
+		ingress.Spec.IngressClassName = &ingressClassName
+	}
+	return ingress
 }


### PR DESCRIPTION
## Summary
- Reconcile generated WordPress Deployment fields when a `WordPressSite` spec changes, including built-in database secret refs, init-container install env vars, PHP memory limit, and the init-container image.
- Keep KubePress-managed WordPress environment variables authoritative while continuing to reconcile user-provided custom `spec.wordpress.env` entries.
- Support tunnel-style Ingress readiness when `status.loadBalancer` is empty by requiring an explicit tunnel signal plus a matching WordPress host/backend route.
- Improve `Ready=False` condition messages so status reflects the readiness step that failed instead of always reporting `WordPress pod not found`.
- Add unit coverage for deployment env reconciliation, managed env-var protection, and Ingress readiness with and without tunnel signals.

## Root Cause
Existing Deployments only refreshed a small subset of generated fields after creation. Host changes updated the Ingress but could leave the init container with stale install-time values such as `WORDPRESS_URL`, and DB/admin secret ref changes could leave existing pods pointed at old secrets.

The readiness check also required `ingress.status.loadBalancer` to contain an address. That works for controllers that publish an external LoadBalancer address, but it can block valid tunnel-based routing setups that intentionally do not publish LoadBalancer status.

## Behavior Changes
- Existing WordPress Deployments now converge built-in WordPress and init-container env vars back to the desired operator-generated values.
- The init container image now tracks `spec.wordpress.image` along with the main WordPress container image.
- Custom WordPress env vars are updated in place when their values change, except for KubePress-managed env var names such as `WORDPRESS_DB_HOST`, `WORDPRESS_URL`, and `WORDPRESS_MEMORY_LIMIT`.
- Ingress readiness still accepts a populated LoadBalancer address as before.
- If LoadBalancer status is empty, readiness can pass only when the Ingress uses a Cloudflare/tunnel-style ingress class (`cloudflare-tunnel`, `cloudflared`, or `cloudflare-warp`) or has `kubepress.hostzero.de/ingress-ready-without-load-balancer: "true"`.
- The tunnel-compatible readiness path also verifies the expected host, `/` prefix path, WordPress service name, and HTTP service port.
- Matching Ingress rules without LoadBalancer status and without an explicit tunnel signal remain NotReady.
- NotReady status messages now identify whether readiness is blocked on pod discovery, container readiness, WordPress installation, or Ingress readiness.

## Validation
- `go test ./internal/controller/wordpress ./internal/controller`
- `go test $(go list ./... | /usr/bin/grep -v /e2e)`
- `go vet $(go list ./... | /usr/bin/grep -v /e2e)`
- `git diff --check`
